### PR TITLE
fit game window's size to the views size when views enabled

### DIFF
--- a/src/ArcadeMaker.Core/Runtime/GameRunner.cs
+++ b/src/ArcadeMaker.Core/Runtime/GameRunner.cs
@@ -287,7 +287,25 @@ namespace ArcadeMaker.Core.Runtime
                 throw new Exception("The specified room is not part of the game.");
 
             Game.CurrentRoom = room;
-            Game.SetWindowsSize(room.Model.Width, room.Model.Height);
+
+
+            // window size is:
+            //    when views disabed: room width and height
+            //    when views enabled: the minimum size that can contain all views (so the max of (view port x + view port width) and (view port y + view port height))
+            int winWidth, winHeight;
+            if (room.Model.Views.Count > 0)
+            {
+                winWidth = (int)room.Model.Views.Where(v => v.Visible).Max(v => v.PortX + v.PortWidth);
+                winHeight = (int)room.Model.Views.Where(v => v.Visible).Max(v => v.PortY + v.PortHeight);
+            }
+            else
+            {
+                winWidth = (int)room.Model.Width;
+                winHeight = (int)room.Model.Height;
+            }
+            Game.SetWindowsSize(winWidth, winHeight);
+
+
             Game.SetCaption(room.Model.Caption);
 
             // run all create events for the new room

--- a/src/ArcadeMaker.IDE/CustomControls/GSColorPicker.cs
+++ b/src/ArcadeMaker.IDE/CustomControls/GSColorPicker.cs
@@ -13,6 +13,7 @@ namespace ArcadeMaker.IDE
     public partial class GSColorPicker : UserControl
     {
         private ColorDialog dlg1 = new ColorDialog(), dlg2 = new ColorDialog();
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color Color1
         {
             get
@@ -27,6 +28,8 @@ namespace ArcadeMaker.IDE
                     Color1Changed?.Invoke(this, value);
             }
         }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color Color2
         {
             get

--- a/src/ArcadeMaker.IDE/CustomControls/RichTextBoxEx.cs
+++ b/src/ArcadeMaker.IDE/CustomControls/RichTextBoxEx.cs
@@ -177,6 +177,7 @@ namespace ArcadeMaker.IDE.CustomControls
 
 
         public bool _lineNumbers;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ShowLineNumbers
         {
             get
@@ -205,6 +206,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private Font _NumberFont;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Font NumberFont
         {
             get { return _NumberFont; }
@@ -218,6 +220,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private LineCounting _NumberLineCounting;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public LineCounting NumberLineCounting
         {
             get { return _NumberLineCounting; }
@@ -231,6 +234,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private StringAlignment _NumberAlignment;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public StringAlignment NumberAlignment
         {
             get { return _NumberAlignment; }
@@ -244,6 +248,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private Color _NumberColor;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color NumberColor
         {
             get { return _NumberColor; }
@@ -256,6 +261,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private bool _NumberLeadingZeroes;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool NumberLeadingZeroes
         {
             get { return _NumberLeadingZeroes; }
@@ -268,6 +274,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private Color _NumberBorder;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color NumberBorder
         {
             get { return _NumberBorder; }
@@ -281,6 +288,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private int _NumberPadding;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int NumberPadding
         {
             get { return _NumberPadding; }
@@ -294,6 +302,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         public Single _NumberBorderThickness;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Single NumberBorderThickness
         {
             get { return _NumberBorderThickness; }
@@ -308,6 +317,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private Color _NumberBackground1;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color NumberBackground1
         {
             get { return _NumberBackground1; }
@@ -320,6 +330,7 @@ namespace ArcadeMaker.IDE.CustomControls
         }
 
         private Color _NumberBackground2;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Color NumberBackground2
         {
             get { return _NumberBackground2; }


### PR DESCRIPTION
Until now, the game window's size was always the room size, which means that if you're using views then you can't control the size of the window and it will always be as big as the room is! Serious bug.
Now, window size is:
    **when views disabed:** room width and height
    **when views enabled:** the minimum size that can contain all views (so the max of (view port x + view port width) and (view port y + view port height))