### PR TITLE
feat: add Exp builtins for clipboard access

### DIFF
--- a/src/ArcadeMaker.Core/IGame.Funcs.cs
+++ b/src/ArcadeMaker.Core/IGame.Funcs.cs
@@ -479,6 +479,19 @@ public partial interface IGame
     Exp.Void ShowMessage(Exp.Instance? _, IValue?[] args);
 
     /// <summary>
+    /// Gets the text currently stored in the system clipboard, or null if the clipboard holds no text.
+    /// </summary>
+    [ExpFunc]
+    IValue? GetClipboardText(Exp.Instance? _, IValue?[] args);
+
+    /// <summary>
+    /// Copies the given text to the system clipboard.
+    /// </summary>
+    [ExpFunc(1)]
+    [Param("text?", ParamType.String, "The text to copy to the clipboard.")]
+    Exp.Void SetClipboardText(Exp.Instance? _, IValue?[] args);
+
+    /// <summary>
     /// Sets the calling instance's direction and speed so it moves towards the specified point.
     /// </summary>
     /// <param name="expinst">The calling runtime instance.</param>

--- a/src/ArcadeMaker.IDE/Debugging/FutileGame.cs
+++ b/src/ArcadeMaker.IDE/Debugging/FutileGame.cs
@@ -37,6 +37,10 @@ internal sealed class FutileGame : ArcadeMaker.Core.IGame
 
     public Exp.Void ShowMessage(Exp.Instance? _, IValue?[] args) => Exp.Void.Return;
 
+    public IValue? GetClipboardText(Exp.Instance? _, IValue?[] args) => null;
+
+    public Exp.Void SetClipboardText(Exp.Instance? _, IValue?[] args) => Exp.Void.Return;
+
     public Exp.Instance GetPressedKeys(Exp.Instance? _, IValue?[] args) => null!;
 
     public BoolValue KeyDown(Exp.Instance? _, IValue?[] args) => false;

--- a/src/Engines/MonoGame/Core/ArcadeMaker.Engines.MonoGame.Core.csproj
+++ b/src/Engines/MonoGame/Core/ArcadeMaker.Engines.MonoGame.Core.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SpriteFontPlus" Version="0.9.2" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\ArcadeMaker.Core\ArcadeMaker.Core.csproj" />

--- a/src/Engines/MonoGame/Core/ArcadeMakerMonoGame.cs
+++ b/src/Engines/MonoGame/Core/ArcadeMakerMonoGame.cs
@@ -25,6 +25,7 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using TextCopy;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace ArcadeMaker.Engines.MonoGame.Core
@@ -534,6 +535,19 @@ namespace ArcadeMaker.Engines.MonoGame.Core
         public Exp.Void ShowMessage(Exp.Instance? _, IValue?[] args)
         {
             MessageBox.Show("Message", ("".ToExpString() + args[0]?.Object?.ToString()).ToString(), ["OK"]);
+            return Exp.Void.Return;
+        }
+
+        public IValue? GetClipboardText(Exp.Instance? _, IValue?[] args)
+        {
+            string? text = ClipboardService.GetText();
+            return text?.ToExpString();
+        }
+
+        public Exp.Void SetClipboardText(Exp.Instance? _, IValue?[] args)
+        {
+            string text = args[0]?.ToString() ?? "";
+            ClipboardService.SetText(text);
             return Exp.Void.Return;
         }
 


### PR DESCRIPTION
Introduce GetClipboardText() and SetClipboardText() engine functions to allow Exp scripts to read from and write to the system clipboard. TextCopy dependency added to MonoGame backend only; functions declared on IGame interface and implemented in backend and IDE stub. Closes #19