### PR TITLE
fix: Audio support for SoundEditor

### DIFF
--- a/src/ArcadeMaker.Core/Resources/Sound.cs
+++ b/src/ArcadeMaker.Core/Resources/Sound.cs
@@ -16,8 +16,7 @@ public class Sound(string name, string filePath, float startVolume, float startP
         Mp3,
         Ogg,
 
-        // NOTE: This attribute currently filters out WMA on windows machine[SupportedOSPlatform("Windows")]
-        // There is no need to filter windows only format since there is no plans to port engine cross-platform
+        [SupportedOSPlatform("Windows")]
         Wma
     }
 

--- a/src/ArcadeMaker.Core/Resources/Sound.cs
+++ b/src/ArcadeMaker.Core/Resources/Sound.cs
@@ -16,7 +16,8 @@ public class Sound(string name, string filePath, float startVolume, float startP
         Mp3,
         Ogg,
 
-        [SupportedOSPlatform("Windows")]
+        // NOTE: This attribute currently filters out WMA on windows machine[SupportedOSPlatform("Windows")]
+        // There is no need to filter windows only format since there is no plans to port engine cross-platform
         Wma
     }
 

--- a/src/ArcadeMaker.IDE/ArcadeMaker.IDE.csproj
+++ b/src/ArcadeMaker.IDE/ArcadeMaker.IDE.csproj
@@ -9,6 +9,21 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <COMReference Include="WMPLib">
+      <WrapperTool>tlbimp</WrapperTool>
+      <VersionMinor>0</VersionMinor>
+      <VersionMajor>1</VersionMajor>
+      <Guid>6bf52a50-394a-11d3-b153-00c04f79faa6</Guid>
+      <Lcid>0</Lcid>
+      <Isolated>false</Isolated>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+
+  <ItemGroup>
+	<!-- Added to resolve Windows.Media library -->
+	<PackageReference Include="Microsoft.Windows.SDK.NET" Version="10.0.18362.6-preview" />
+	  
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.2" />
     <PackageReference Include="RectpackSharp" Version="1.2.0" />

--- a/src/ArcadeMaker.IDE/ArcadeMaker.IDE.csproj
+++ b/src/ArcadeMaker.IDE/ArcadeMaker.IDE.csproj
@@ -9,18 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <COMReference Include="WMPLib">
-      <WrapperTool>tlbimp</WrapperTool>
-      <VersionMinor>0</VersionMinor>
-      <VersionMajor>1</VersionMajor>
-      <Guid>6bf52a50-394a-11d3-b153-00c04f79faa6</Guid>
-      <Lcid>0</Lcid>
-      <Isolated>false</Isolated>
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-
-  <ItemGroup>
 	<!-- Added to resolve Windows.Media library -->
 	<PackageReference Include="Microsoft.Windows.SDK.NET" Version="10.0.18362.6-preview" />
 	  

--- a/src/ArcadeMaker.IDE/Forms/Editors/SoundEditor.cs
+++ b/src/ArcadeMaker.IDE/Forms/Editors/SoundEditor.cs
@@ -12,16 +12,27 @@ using IntelliSense.CSharp;
 using Exp;
 using System.Runtime.Versioning;
 using ArcadeMaker.IDE.Items;
+using Windows.Media.Core;
+using Windows.Media.Playback;
 
 namespace ArcadeMaker.IDE
 {
     public partial class SoundEditor : Form
     {
         private GameSound sound = null;
+
+        // new sound control objects
+        private readonly MediaPlayer _player;
+        private bool paused = false;
+
         public SoundEditor(GameSound sound)
         {
             InitializeComponent();
             this.sound = sound;
+
+            // init player
+            _player = new MediaPlayer();
+            _player.MediaEnded += SoundPlayer_MediaEnded;
 
             // set file dialog format
             var crossPlatformFormats = SupportedFormats.Where(f => string.IsNullOrWhiteSpace(f.Comment)).Map(f => f.Format);
@@ -70,6 +81,7 @@ namespace ArcadeMaker.IDE
         {
             //soundPlayer?.Dispose();
             Close();
+            _player.Dispose();
         }
 
         private void MusicEditor_Load(object sender, EventArgs e)
@@ -97,22 +109,22 @@ namespace ArcadeMaker.IDE
         }
 
         //private AudioPlayer soundPlayer = null;
-        private bool isPlaying = false;
         private void playBtn_Click(object sender, EventArgs e)
         {
-            if (isPlaying)
-                return;
             if (sound.Data != null)
             {
                 try
                 {
-                    //soundPlayer = new WaveOut();
-                    //soundPlayer.PlaybackStopped += SoundPlayer_PlaybackStopped;
-                    //reader = new AudioFileReader(sound.filePath);
-                    //reader.Volume = sound.volume;
-                    //soundPlayer.Init(reader);
-                    //soundPlayer.Play();
-                    isPlaying = true;
+                    if (paused)
+                    {
+                        _player.Play();
+                        paused = false;
+                        return;
+                    }
+
+                    _player.Source = MediaSource.CreateFromUri(new Uri(sound.FilePath));
+                    _player.Volume = sound.volume;
+                    _player.Play();
                 }
                 catch (Exception ex)
                 {
@@ -129,43 +141,34 @@ namespace ArcadeMaker.IDE
             }
         }
 
-        private bool userStoppedAudio = false;
-        private void SoundPlayer_PlaybackStopped(object sender, object e)
+        private void pauseBtn_Click(object sender, EventArgs e)
         {
-            //Global.ShowDebugMessage("playback stopped");
-            if (!userStoppedAudio)
+            if (_player != null)
             {
-                //reader.Position = 0;
-                //soundPlayer.Play();
+                try
+                {
+                    _player.Pause();
+                    paused = true;
+                }
+                catch (Exception ex)
+                {
+                    string err = "Error: Cannot pause";
+#if DEBUG
+                    err += "\n\nError message:\n" + ex.Message;
+#endif
+                    MessageBox.Show(err);
+                }
+            }
+            else
+            {
+                MessageBox.Show("Nothing is being played");
             }
         }
 
-        private void pauseBtn_Click(object sender, EventArgs e)
+        private void SoundPlayer_MediaEnded(MediaPlayer sender, object args)
         {
-            //            if (soundPlayer != null && isPlaying)
-            //            {
-            //                try
-            //                {
-            //                    userStoppedAudio = true;
-            //                    soundPlayer.Stop();
-            //                    soundPlayer.Dispose();
-            //                    reader?.Dispose();
-            //                    userStoppedAudio = false;
-            //                    isPlaying = false;
-            //                }
-            //                catch (Exception ex)
-            //                {
-            //                    string err = "Error: Cannot pause";
-            //#if DEBUG
-            //                    err += "\n\nError message:\n" + ex.Message;
-            //#endif
-            //                    MessageBox.Show(err);
-            //                }
-            //            }
-            //            else
-            //            {
-            //                MessageBox.Show("Nothing is being played");
-            //            }
+            paused = false;
+            _player.PlaybackSession.Position = TimeSpan.Zero;
         }
 
         private void loadBtn_Click(object sender, EventArgs e)

--- a/src/ArcadeMaker.IDE/Items/GameSound.cs
+++ b/src/ArcadeMaker.IDE/Items/GameSound.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 
 namespace ArcadeMaker.IDE.Items
 {
@@ -11,6 +12,10 @@ namespace ArcadeMaker.IDE.Items
     {
         public static Bitmap Icon => Properties.Resources.sound;
         public byte[]? Data { get; private set; }
+
+        // Expose filepath for windows media player consumption
+        [XmlIgnore]
+        public string? FilePath { get; private set; }
 
         /// <summary>
         /// The extension of the file that this sound was load from, including the opening dot, e.g. ".mp3".
@@ -49,11 +54,17 @@ namespace ArcadeMaker.IDE.Items
         public void SetSource(string? file)
         {
             if (file == null)
+            {
                 SetSource(null, null);
+                FilePath = null;
+            }
+                
             else
             {
                 string ext = System.IO.Path.GetExtension(file) ?? throw new ArgumentException($"The given file must have an extenion.\n(Given file: {file}).", paramName: nameof(file));
                 SetSource(ext, File.ReadAllBytes(file));
+
+                FilePath = file;
             }
         }
 


### PR DESCRIPTION
Added support for playing sounds in Sound Editor via `Windows.Media` pulled from `Microsoft.Windows.SDK.NET`.
For easier MediaPlayer initialization,  GameSound now exposes FilePath property which is currently being ignored by XmlParser.
In assumption that engine won't gone cross platform, I removed windows only filter from .WMA file extension.

Currently supported and tested files:
- MP3
- OGG
- WAW
- WMA

If you prefer so, you can test it whit provided file samples here
[test-samples.zip](https://github.com/user-attachments/files/31276137/test-samples.zip)